### PR TITLE
Issue/fix symlink stat 2

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,8 +24,8 @@ jobs:
           venv/bin/pip list | grep inmanta
       - name: Lint with flake8
         run: |
-          venv/bin/flake8 tests inmanta_plugins
-          venv/bin/pyupgrade --py39-plus $(find inmanta_plugins tests -type f -name '*.py')
+          venv/bin/flake8 tests inmanta_plugins inmanta_files
+          venv/bin/pyupgrade --py39-plus $(find inmanta_plugins tests inmanta_files -type f -name '*.py')
 
   tests:
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 inmanta_plugins/**/__pycache__
+inmanta_files/__pycache__
 tests/**/__pycache__
 *.orig
 .vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.0.1 - ?
 
+- Fix symlink stat operation, move helper to non-namespace package
 
 ## v1.0.0 - 2024-08-04
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include inmanta_plugins/files/setup.cfg
 include inmanta_plugins/files/py.typed
+include inmanta_files/py.typed
 recursive-include inmanta_plugins/files/model *.cf
 graft inmanta_plugins/files/files
 graft inmanta_plugins/files/templates

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-isort = isort inmanta_plugins tests
-black_preview = black --preview inmanta_plugins tests
-black = black inmanta_plugins tests
-flake8 = flake8 inmanta_plugins tests
+isort = isort inmanta_plugins tests inmanta_files
+black_preview = black --preview inmanta_plugins tests inmanta_files
+black = black inmanta_plugins tests inmanta_files
+flake8 = flake8 inmanta_plugins tests inmanta_files
 
 format:
 	$(isort)

--- a/inmanta_files/__init__.py
+++ b/inmanta_files/__init__.py
@@ -18,9 +18,10 @@ Contact: edvgui@gmail.com
 This module contains some code that will be executed on a remote host
 using mitogen.
 """
+
+import grp
 import os
 import pwd
-import grp
 
 
 def symlink_stat(path: str) -> dict[str, object]:

--- a/inmanta_files/__init__.py
+++ b/inmanta_files/__init__.py
@@ -1,0 +1,47 @@
+"""
+Copyright 2023 Guillaume Everarts de Velp
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Contact: edvgui@gmail.com
+
+This module contains some code that will be executed on a remote host
+using mitogen.
+"""
+import os
+import pwd
+import grp
+
+
+def symlink_stat(path: str) -> dict[str, object]:
+    """
+    This method is similar to inmanta_mitogen.file_stat excepts that it doesn't
+    try to resolve the symlink on the last element of the path (all other
+    symlinks will be resolved).
+
+    :param path: The path to stat.
+    """
+    # Resolve all the symlinks except the one at the end of the path
+    parent_path = os.path.abspath(os.path.join(path, os.pardir))
+    resolved_parent_path = os.path.realpath(parent_path)
+
+    # Get the stat result for the symlink at the end of the path
+    stat_result = os.stat(
+        os.path.join(resolved_parent_path, os.path.basename(path)),
+        follow_symlinks=False,
+    )
+    return dict(
+        owner=pwd.getpwuid(stat_result.st_uid).pw_name,
+        group=grp.getgrgid(stat_result.st_gid).gr_name,
+        permissions=int(oct(stat_result.st_mode)[-4:]),
+    )

--- a/inmanta_plugins/files/symlink.py
+++ b/inmanta_plugins/files/symlink.py
@@ -16,10 +16,6 @@ limitations under the License.
 Contact: edvgui@gmail.com
 """
 
-import grp
-import os
-import pwd
-
 import inmanta.agent.agent
 import inmanta.agent.handler
 import inmanta.agent.io.local
@@ -30,6 +26,8 @@ import inmanta.resources
 import inmanta_plugins.files.base
 import inmanta_plugins.files.json
 
+import inmanta_files
+
 
 @inmanta.resources.resource(
     name="files::Symlink",
@@ -39,30 +37,6 @@ import inmanta_plugins.files.json
 class SymlinkResource(inmanta_plugins.files.base.BaseFileResource):
     fields = ("target",)
     target: str
-
-
-def symlink_stat(path: str) -> dict[str, object]:
-    """
-    This method is similar to inmanta_mitogen.file_stat excepts that it doesn't
-    try to resolve the symlink on the last element of the path (all other
-    symlinks will be resolved).
-
-    :param path: The path to stat.
-    """
-    # Resolve all the symlinks except the one at the end of the path
-    parent_path = os.path.abspath(os.path.join(path, os.pardir))
-    resolved_parent_path = os.path.realpath(parent_path)
-
-    # Get the stat result for the symlink at the end of the path
-    stat_result = os.stat(
-        os.path.join(resolved_parent_path, os.path.basename(path)),
-        follow_symlinks=False,
-    )
-    return dict(
-        owner=pwd.getpwuid(stat_result.st_uid).pw_name,
-        group=grp.getgrgid(stat_result.st_gid).gr_name,
-        permissions=int(oct(stat_result.st_mode)[-4:]),
-    )
 
 
 @inmanta.agent.handler.provider("files::Symlink", "")
@@ -95,7 +69,7 @@ class SymlinkHandler(inmanta_plugins.files.base.BaseFileHandler[SymlinkResource]
             )
 
         for key, value in self.proxy.remote_call(
-            symlink_stat,
+            inmanta_files.symlink_stat,
             resource.path,
         ).items():
             if getattr(resource, key) is not None:

--- a/inmanta_plugins/files/symlink.py
+++ b/inmanta_plugins/files/symlink.py
@@ -23,10 +23,9 @@ import inmanta.const
 import inmanta.execute.proxy
 import inmanta.export
 import inmanta.resources
+import inmanta_files
 import inmanta_plugins.files.base
 import inmanta_plugins.files.json
-
-import inmanta_files
 
 
 @inmanta.resources.resource(

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ install_requires =
 
 [options.packages.find]
 include = inmanta_plugins*
+    inmanta_files
 
 [flake8]
 # H101 Include your name with TODOs as in # TODO(yourname). This makes it easier to find out who the author of the comment was.


### PR DESCRIPTION
# Description

Fix (again) the stat logic for symlink, making sure it can be loaded by mitogen

note: to add a changelog entry and bump the version number:
`inmanta module release --dev [--major|--minor|--patch] [--changelog-message "<your_changelog_message>"]`

# [Merge procedure](https://internal.inmanta.com/development/core/tasks/commiting-changes-modules.html)

1. merge using the merge button
2. tag and bump

```sh
git checkout master
git pull
inmanta module release
git push
git push {tag} # push the tag as well
```
3. Remove the branch

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
