### PR TITLE
Issue/self dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v2.2.1 - ?
 
+- Fix deployment on new executor
 
 ## v2.2.0 - 2025-04-10
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,9 @@ install_requires =
     inmanta-module-std<9
     inmanta-module-mitogen<1
     inmanta-core>=15.1.0
+    # Add a dependency to itself, to make sure that the inmanta_files package
+    # is always installed in the executor where the resources are used
+    inmanta-module-files
 
 [options.packages.find]
 include = inmanta_plugins*


### PR DESCRIPTION
# Description

- With the new executor, it is less likely that the resources of this module get deployed on the same process as other modules depending on this one.  That causes the inmanta_files package to not be installed (as the module package is not a dependency of anything).  To mitigate that, add the dependency to the module itself, it is a bit silly, but it works

note: to add a changelog entry and bump the version number:
`inmanta module release --dev [--major|--minor|--patch] [--changelog-message "<your_changelog_message>"]`

# [Merge procedure](https://internal.inmanta.com/development/core/tasks/commiting-changes-modules.html)

1. merge using the merge button
2. tag and bump

```sh
git checkout master
git pull
inmanta module release
git push
git push {tag} # push the tag as well
```
3. Remove the branch

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
