### PR TITLE
Allow reference values in serialized JsonResource attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v2.9.2 - ?
 
+- Allow reference values in serialized JsonResource attributes (scalars and values nested in dicts/lists), passing them
+  through to the resource so they are resolved by the handler at deploy time.
+
 
 ## v2.9.1 - 2026-06-12
 

--- a/inmanta_plugins/files/json.py
+++ b/inmanta_plugins/files/json.py
@@ -89,15 +89,26 @@ def json_value(raw_value: object) -> object:
     a mutable, json-like python object.  Sequences are converted into
     lists, and Mappings into dicts.  Any other value is kept as is.
 
+    Reference values (or references nested in dicts/lists) are passed
+    through unchanged so they can be resolved by the handler at deploy
+    time.  Because ``allow_reference_values`` only opts in a single proxy
+    level, it is re-applied each time we descend into a collection.
+
     :param raw_value: The raw value that should be converted.
     """
     match raw_value:
         case str():
             return raw_value
         case Sequence() | SequenceProxy():
-            return [json_value(item) for item in raw_value]
+            return [
+                json_value(item)
+                for item in inmanta.plugins.allow_reference_values(raw_value)
+            ]
         case Mapping():
-            return {k: json_value(v) for k, v in raw_value.items()}
+            return {
+                k: json_value(v)
+                for k, v in inmanta.plugins.allow_reference_values(raw_value).items()
+            }
         case _:
             return raw_value
 
@@ -321,7 +332,10 @@ def get_instance_attributes(
             attr_name, attr_name
         )
         attributes[serialized_name] = json_value(
-            getattr(serializable_entity, attr_name)
+            getattr(
+                inmanta.plugins.allow_reference_values(serializable_entity),
+                attr_name,
+            )
         )
 
     return attributes

--- a/tests/test_json_serialized_entity.py
+++ b/tests/test_json_serialized_entity.py
@@ -18,6 +18,7 @@ Contact: edvgui@gmail.com
 
 import pytest_inmanta.plugin
 
+import inmanta.references
 from inmanta_plugins.files.json import (
     Operation,
     SerializedEntity,
@@ -169,6 +170,61 @@ a = Test(
                 },
             ],
         },
+    )
+
+
+def test_reference_scalar_attribute(
+    project: pytest_inmanta.plugin.Project,
+) -> None:
+    """
+    A serialized attribute that is itself a reference must be passed through
+    to the serialized value, not rejected during compilation.
+    """
+    model = """
+import std
+
+a = Test(
+    name=std::create_environment_reference("NAME"),
+    required=RequiredEmbeddedTest(name="required"),
+    path=".",
+    operation=files::replace,
+    resource=files::json::JsonResource(),
+)
+"""
+
+    project.compile(TYPE_DEFINITION + model)
+
+    instance = project.get_instances("__config__::Test")[0]
+    serialized = serialize(instance)
+    assert isinstance(serialized.value["name"], inmanta.references.Reference)
+
+
+def test_reference_in_dict_attribute(
+    project: pytest_inmanta.plugin.Project,
+) -> None:
+    """
+    A reference nested inside a dict attribute value must be passed through
+    to the serialized value, not rejected during compilation.
+    """
+    model = """
+import std
+
+a = Test(
+    name="test",
+    attr={"Authorization": std::create_environment_reference("AUTH_TOKEN")},
+    required=RequiredEmbeddedTest(name="required"),
+    path=".",
+    operation=files::replace,
+    resource=files::json::JsonResource(),
+)
+"""
+
+    project.compile(TYPE_DEFINITION + model)
+
+    instance = project.get_instances("__config__::Test")[0]
+    serialized = serialize(instance)
+    assert isinstance(
+        serialized.value["attr"]["Authorization"], inmanta.references.Reference
     )
 
 


### PR DESCRIPTION
# Description

serialize_for_resource walks the SerializableEntity tree at compile time through DSL DynamicProxy objects without opting into reference values, so any serialized attribute (or a value nested in a dict/list attribute) that is a Reference raised UnexpectedReference.

Re-apply allow_reference_values() at every proxy level traversed: on the getattr in get_instance_attributes and on each dict/list before iterating in json_value. References then fall through unchanged and land in the resource attributes to be resolved by the handler at deploy time.

note: to add a changelog entry and bump the version number:
`inmanta module release --dev [--major|--minor|--patch] [--changelog-message "<your_changelog_message>"]`

# [Merge procedure](https://internal.inmanta.com/development/core/tasks/commiting-changes-modules.html)

1. merge using the merge button
2. tag and bump

```sh
git checkout master
git pull
inmanta module release
git push
git push {tag} # push the tag as well
```
3. Remove the branch

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
