### PR TITLE
Issue/json resource optional serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v2.11.0 - ?
 
+- Automatically add JsonResource serialized entities to JsonFile resources when the serialized entity extends JsonResource
 - Allow to skip in-model serialization of JsonResource.
 
 ## v2.10.0 - 2026-06-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## v2.10.1 - ?
+## v2.11.0 - ?
 
+- Allow to skip in-model serialization of JsonResource.
 
 ## v2.10.0 - 2026-06-20
 

--- a/inmanta_plugins/files/json.py
+++ b/inmanta_plugins/files/json.py
@@ -720,15 +720,43 @@ class JsonFileResource(inmanta_plugins.files.base.BaseFileResource):
                     f"all paths must start with {path_prefix}"
                 )
 
+        values = {
+            validate_path(value.path): {
+                "path": validate_path(value.path),
+                "operation": value.operation,
+                "value": value.value,
+            }
+            for value in entity.values
+        }
+
+        # If the resource also extends JsonResource, get all the serialized items
+        # and add them to our values list
+        if "files::json::JsonResource" in entity._type().get_all_parent_names():
+            if entity.serialize:
+                # The serialized entities are already present in the model, simply
+                # pick them up
+                serialized_entities = typing.cast(
+                    list[SerializableEntity], entity.serialized
+                )
+            else:
+                # Serialization is not done in the model, do it now
+                serialized_entities = serialize_for_resource(entity.root, entity)
+
+            # Add all serialized entities which are not in the object list yet
+            for serialized in serialized_entities:
+                values.setdefault(
+                    serialized.path,
+                    {
+                        "path": serialized.path,
+                        "operation": serialized.operation,
+                        "value": (
+                            serialized.value if serialized.value is not None else {}
+                        ),
+                    },
+                )
+
         return sorted(
-            [
-                {
-                    "path": validate_path(value.path),
-                    "operation": value.operation,
-                    "value": value.value,
-                }
-                for value in entity.values
-            ],
+            values.values(),
             key=lambda d: d["path"],
         )
 

--- a/model/json.cf
+++ b/model/json.cf
@@ -94,7 +94,13 @@ entity JsonResource extends std::Resource:
     This entity takes care of serializing all the attached entities into a list of
     of objects (SerializedEntity) that can be used in the handler to update the
     current state object with the content of the desired state.
+
+    :attr serialize: When true, run the serialization of the resource in-compile.
+        This allows to use the serialized entities in the model, but it comes at
+        a performance cost, as the serialization plugins are expensive to run on
+        a module with many unset values.
     """
+    bool serialize = true
 end
 JsonResource.root [0:1] -- SerializableEntity
 """
@@ -228,7 +234,7 @@ implementation serialize_entities for JsonResource:
 
     # If at least one entity is attached, serialize the full tree
     # and attach each entity into the serialized relation
-    if self.root is defined:
+    if self.root is defined and self.serialize:
         # TODO: https://github.com/edvgui/inmanta-module-files/issues/136
         self.serialized = [
             SerializedEntity(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = inmanta-module-files
-version = 2.10.1
+version = 2.11.0
 description = Simple module containing various types of resource to manage files.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_json_resource.py
+++ b/tests/test_json_resource.py
@@ -1,0 +1,184 @@
+"""
+Copyright 2026 Guillaume Everarts de Velp
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Contact: edvgui@gmail.com
+"""
+
+import grp
+import json
+import os
+import pathlib
+
+import pytest
+import pytest_inmanta.plugin
+
+# A json file resource that also extends files::json::JsonResource: the attached
+# SerializableEntity tree is serialized into the file managed by the resource.
+# This is the same pattern as the gatus config file of the misty module.
+TYPE_DEFINITION = """
+import files
+import files::json
+
+
+entity ConfigFile extends files::json::JsonResource, files::SharedJsonFile:
+    \"\"\"
+    A configuration file whose desired state is the serialized version of the
+    attached Config entity tree.  The exported resource is a files::SharedJsonFile.
+    \"\"\"
+end
+ConfigFile.config [1] -- Config
+
+
+entity Config extends files::json::SerializableEntity:
+    string path = "."
+end
+Config.endpoints [0:] -- Endpoint.parent [1]
+
+
+entity Endpoint extends files::json::SerializableEntity:
+    string name
+    string url
+    string? group = null
+end
+index Endpoint(parent, name)
+
+
+implementation config_file for ConfigFile:
+    # Connect the root of the configuration tree, and attach it to this resource
+    self.root = self.config
+    self.root.resource = self
+end
+
+
+implement ConfigFile using config_file, parents
+implement Config using parents
+implement Endpoint using parents
+"""
+
+
+def test_model(
+    project: pytest_inmanta.plugin.Project,
+    file_path: pathlib.Path = pathlib.Path("/tmp/example"),
+    purged: bool = False,
+    serialize: bool = True,
+) -> None:
+    user = os.getlogin()
+    group = grp.getgrgid(os.getgid()).gr_name
+
+    model = TYPE_DEFINITION + f"""
+        import mitogen
+        import std
+
+        host = std::Host(
+            name="localhost",
+            os=std::linux,
+            via=mitogen::Local(),
+        )
+
+        ConfigFile(
+            host=host,
+            path={repr(str(file_path))},
+            owner={repr(user)},
+            group={repr(group)},
+            purged={str(purged).lower()},
+            serialize={str(serialize).lower()},
+            config=Config(
+                endpoints=[
+                    Endpoint(name="bob", url="https://bob.example.com"),
+                    Endpoint(
+                        name="alice",
+                        url="https://alice.example.com",
+                        group="friends",
+                    ),
+                ],
+            ),
+        )
+    """
+
+    project.compile(model, no_dedent=False)
+
+    # The serialized entities are only materialized in the model when the
+    # serialization is requested to happen in-compile.
+    resource = project.get_instances("__config__::ConfigFile")[0]
+    if serialize:
+        serialized = {s.path: dict(s.value) for s in resource.serialized}
+        assert serialized == {
+            ".": {},
+            "endpoints[name=alice]": {
+                "name": "alice",
+                "url": "https://alice.example.com",
+                "group": "friends",
+            },
+            "endpoints[name=bob]": {
+                "name": "bob",
+                "url": "https://bob.example.com",
+            },
+        }
+    else:
+        assert list(resource.serialized) == []
+
+
+@pytest.mark.parametrize("serialize", [True, False])
+def test_deploy(
+    project: pytest_inmanta.plugin.Project,
+    tmp_path: pathlib.Path,
+    serialize: bool,
+) -> None:
+    file = tmp_path / "config.json"
+
+    def read_endpoints() -> list[dict]:
+        return json.loads(file.read_text())["endpoints"]
+
+    expected = [
+        {"name": "bob", "url": "https://bob.example.com"},
+        {"name": "alice", "url": "https://alice.example.com", "group": "friends"},
+    ]
+
+    def assert_endpoints() -> None:
+        endpoints = read_endpoints()
+        assert sorted(endpoints, key=lambda e: e["name"]) == sorted(
+            expected, key=lambda e: e["name"]
+        )
+
+    # Create the file out of the serialized config tree.  Whether the
+    # serialization happens in-compile (serialize=true) or at export time
+    # (serialize=false), the deployed content is identical.
+    test_model(project, file, purged=False, serialize=serialize)
+    assert project.dryrun_resource("__config__::ConfigFile", uri=str(file))
+    project.deploy_resource("__config__::ConfigFile", uri=str(file))
+    assert_endpoints()
+    assert not project.dryrun_resource("__config__::ConfigFile", uri=str(file))
+
+    # Drop a managed endpoint from the file and make sure we detect and fix it
+    content = json.loads(file.read_text())
+    content["endpoints"] = [e for e in content["endpoints"] if e["name"] != "alice"]
+    file.write_text(json.dumps(content))
+    assert project.dryrun_resource("__config__::ConfigFile", uri=str(file))
+    project.deploy_resource("__config__::ConfigFile", uri=str(file))
+    assert_endpoints()
+    assert not project.dryrun_resource("__config__::ConfigFile", uri=str(file))
+
+    # An unmanaged endpoint left in the file is not touched
+    content = json.loads(file.read_text())
+    content["endpoints"].append({"name": "eve", "url": "https://eve.example.com"})
+    file.write_text(json.dumps(content))
+    assert not project.dryrun_resource("__config__::ConfigFile", uri=str(file))
+
+    # Delete the file
+    test_model(project, file, purged=True, serialize=serialize)
+    assert project.dryrun_resource("__config__::ConfigFile", uri=str(file))
+    project.deploy_resource("__config__::ConfigFile", uri=str(file))
+    assert not file.exists()
+    assert not project.dryrun_resource("__config__::ConfigFile", uri=str(file))


### PR DESCRIPTION
# Description

- Automatically add JsonResource serialized entities to JsonFile resources when the serialized entity extends JsonResource
- Allow to skip in-model serialization of JsonResource.

note: to add a changelog entry and bump the version number:
`inmanta module release --dev [--major|--minor|--patch] [--changelog-message "<your_changelog_message>"]`

# [Merge procedure](https://internal.inmanta.com/development/core/tasks/commiting-changes-modules.html)

1. merge using the merge button
2. tag and bump

```sh
git checkout master
git pull
inmanta module release
git push
git push {tag} # push the tag as well
```
3. Remove the branch

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )
